### PR TITLE
Fixed readme version typo from 18 to 20.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Ansible > 2.6.5
 Example Playbook
 ----------------
 
-This sample playbook should be run in a folder that is above the main UBUNTU-18-CIS folder.
+This sample playbook should be run in a folder that is above the main UBUNTU-20-CIS folder.
 
 ```
 - hosts: all


### PR DESCRIPTION
I know this is incredibly trivial, but I saw this error in your documentation and thought I'd suggest a fix.