### PR TITLE
Fix Ansible aborts in check-mode because of undefined variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
 # - debug: var=ansible_facts
 - name: Gather distribution info
+  # we need:
+  # - hardware for ansible_mounts
+  # - platform for ansible_architecture (ansible internal)
+  # - virtual for ansible_virtualization_type
   setup:
-      gather_subset: distribution,!all,!min
+      gather_subset: distribution,hardware,platform,virtual,!all,!min
   when:
       - ansible_distribution is not defined
   tags:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -44,6 +44,7 @@
 - name: "PRELIM | List users accounts"
   command: "awk -F: '{print $1}' /etc/passwd"
   changed_when: false
+  check_mode: false
   register: ubtu20cis_users
   when:
       - ubtu20cis_rule_6_2_8 or

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -252,6 +252,7 @@
         shell: mount | grep "on /var "
         changed_when: false
         failed_when: false
+        check_mode: false
         args:
             warn: false
         register: ubtu20cis_1_1_10_var_mounted
@@ -277,6 +278,7 @@
         shell: mount | grep "on /var/tmp "
         changed_when: false
         failed_when: false
+        check_mode: false
         args:
             warn: false
         register: ubtu20cis_1_1_11_var_tmp_mounted
@@ -326,6 +328,7 @@
         shell: mount | grep "on /var/log "
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_1_1_15_var_log_mounted
         args:
             warn: false
@@ -351,6 +354,7 @@
         shell: mount | grep "on /var/log/audit "
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_1_1_16_var_log_audit_mounted
         args:
             warn: false
@@ -375,6 +379,7 @@
         shell: mount | grep "on /home"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_1_1_17_home_mounted
         args:
             warn: false
@@ -453,6 +458,7 @@
 - name: "1.1.22 | PATCH | Ensure sticky bit is set on all world-writable directories"
   shell: df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null | xargs -I '{}' chmod a+t '{}'
   failed_when: ubtu20cis_1_1_22_status.rc>0
+  check_mode: false
   register: ubtu20cis_1_1_22_status
   when:
       - ubtu20cis_rule_1_1_22
@@ -509,6 +515,7 @@
         command: apt-cache policy
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_1_2_1_apt_policy
 
       - name: "1.2.1 | AUDIT | Ensure package manager repositories are configured | Message out repository configs"
@@ -533,6 +540,7 @@
         command: apt-key list
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_1_2_2_apt_gpgkeys
 
       - name: "1.2.2 | AUDIT | Ensure GPG keys are configured | Message out apt gpg keys"
@@ -641,6 +649,7 @@
   command: /bin/true
   changed_when: false
   failed_when: false
+  check_mode: false
   when:
       - ubtu20cis_rule_1_5_1
   tags:
@@ -656,6 +665,7 @@
       - name: "1.5.2 | AUDIT | Ensure permissions on bootloader config are configured | Check for Grub file"
         stat:
             path: /boot/grub/grub.cfg
+        check_mode: false
         register: ubtu20cis_1_5_2_grub_cfg_status
 
       - name: "1.5.2 | PATCH | Ensure permissions on bootloader config are configured | Set permissions"
@@ -694,6 +704,7 @@
         shell: "journalctl | grep 'protection: active'"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_1_6_1_xdnx_status
 
       - name: "1.6.1 | AUDIT | Ensure XD/NX support is enabled | Alert if XD/NX is not enabled"
@@ -788,6 +799,7 @@
         shell: grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_1_7_1_2_cmdline_settings
 
       - name: "1.7.1.2 | PATCH | Ensure AppArmor is enabled in the bootloader configuration | Set apparmor settings if none exist"

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -95,6 +95,7 @@
         shell: grep {{ ubtu20cis_chrony_user }} /etc/passwd
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_2_2_1_3_chrony_user_status
 
       - name: "2.2.1.3 | PATCH | Ensure chrony is configured | Set chrony.conf file"
@@ -548,6 +549,7 @@
         shell: lsof -i -P -n | grep -v "(ESTABLISHED)"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_2_4_services
 
       - name: "2.4 | AUDIT | Ensure nonessential services are removed or masked | Message out running services"

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -5,6 +5,7 @@
         shell: grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_3_1_1_grub_cmdline_linux_settings
 
       - name: "3.1.1 | PATCH | Disable IPv6 | Add ipv6.disable if does not exist"
@@ -44,6 +45,7 @@
         shell: dpkg -l | grep network-manager
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_3_1_2_network_manager_status
 
       - name: "3.1.2 | PATCH | Ensure wireless interfaces are disabled | Disable wireless if network-manager installed"
@@ -528,12 +530,14 @@
         command: ss -4tuln
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_3_5_1_6_open_listen_ports
 
       - name: "3.5.1.6 | AUDIT | Ensure firewall rules exist for all open ports | Get list of firewall rules"
         command: ufw status
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_3_5_1_6_firewall_rules
 
       - name: "3.5.1.6 | AUDIT | Ensure firewall rules exist for all open ports | Message out settings"
@@ -634,6 +638,7 @@
   # command: "nft create table {{ ubtu20cis_nftables_table_name }}"
   # changed_when: ubtu20cis_3_5_2_4_new_table.rc == 0
   # failed_when: false
+  # check_mode: false
   # register: ubtu20cis_3_5_2_4_new_table
   when:
       - ubtu20cis_rule_3_5_2_4
@@ -684,18 +689,21 @@
   #       shell: nft list ruleset | awk '/hook input/,/}/' | grep 'iif "lo" accept'
   #       changed_when: false
   #       failed_when: false
+  #       check_mode: false
   #       register: ubtu20cis_3_5_2_6_loopback_iif_status
 
   #     - name: "3.5.2.6 | AUDIT | Ensure loopback traffic is configured | Get input iif lo accept status"
   #       shell: nft list ruleset | awk '/hook input/,/}/' | grep 'ip saddr'
   #       changed_when: false
   #       failed_when: false
+  #       check_mode: false
   #       register: ubtu20cis_3_5_2_6_loopback_input_drop_status
 
   #     - name: "3.5.2.6 | AUDIT | Ensure loopback traffic is configured | Get input iif lo accept status"
   #       shell: nft list ruleset | awk '/hook input/,/}/' | grep 'ip6 saddr'
   #       changed_when: false
   #       failed_when: false
+  #       check_mode: false
   #       register: ubtu20cis_3_5_2_6_loopback_ipv6_drop_status
 
   #     - name: "3.5.2.6 | PATCH | Ensure loopback traffic is configured | Loopback iif lo accept"
@@ -946,12 +954,14 @@
         command: ss -4tuln
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_3_5_3_2_4_open_ports
 
       - name: "3.5.3.2.4 | AUDIT | Ensure firewall rules exist for all open ports | Get list of rules"
         command: iptables -L INPUT -v -n
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_3_5_3_2_4_current_rules
 
       - name: "3.5.3.2.4 | AUDIT | Ensure firewall rules exist for all open ports | Alert about settings"
@@ -1113,12 +1123,14 @@
         command: ss -6tuln
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_3_5_3_3_4_open_ports
 
       - name: "3.5.3.3.4 | AUDIT | Ensure IPv6 firewall rules exist for all open ports | Get list of rules"
         command: ip6tables -L INPUT -v -n
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_3_5_3_3_4_current_rules
 
       - name: "3.5.3.3.4 | AUDIT | Ensure IPv6 firewall rules exist for all open ports | Alert about settings"

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -32,6 +32,7 @@
         shell: grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_4_1_1_3_cmdline_settings
 
       - name: "4.1.1.3 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Add setting if doesn't exist"
@@ -66,6 +67,7 @@
         shell: grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_4_1_1_4_cmdline_settings
 
       - name: "4.1.1.4 | PATCH | Ensure audit_backlog_limit is sufficient | Add setting if doesn't exist"
@@ -285,7 +287,7 @@
         shell: for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do find $i -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null; done
         register: priv_procs
         changed_when: no
-        check_mode: no
+        check_mode: false
 
       - name: "4.1.11 | PATCH | Ensure use of privileged commands is collected | Set privileged rules"
         template:
@@ -440,12 +442,14 @@
         shell: grep -r "*.emerg" /etc/* | cut -f1 -d":"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_4_2_1_3_rsyslog_config_path
 
       - name: "4.2.1.3 | AUDIT | Ensure logging is configured | Gather rsyslog current config"
         command: "cat {{ ubtu20cis_4_2_1_3_rsyslog_config_path.stdout }}"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_4_2_1_3_rsyslog_config
 
       - name: "4.2.1.3 | AUDIT | Ensure logging is configured | Message out config"
@@ -605,6 +609,7 @@
 - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured"
   command: find /var/log -type f -exec chmod g-wx,o-rwx "{}" + -o -type d -exec chmod g-w,o-rwx "{}" +
   changed_when: ubtu20cis_4_2_3_logfile_perms_status.rc == 0
+  check_mode: false
   register: ubtu20cis_4_2_3_logfile_perms_status
   when:
       - ubtu20cis_rule_4_2_3
@@ -621,6 +626,7 @@
       - name: "4.3 | PATCH | Ensure logrotate is configured | Get logrotate files"
         find:
             paths: /etc/logrotate.d/
+        check_mode: false
         register: ubtu20cis_4_3_logrotate_files
 
       - name: "4.3 | PATCH | Ensure logrotate is configured | Set rotation configurations"

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -565,6 +565,7 @@
         command: grep 'password.*requisite.*pam_pwquality.so' /etc/pam.d/common-password
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_5_3_1_pam_pwquality_state
 
       - name: "5.3.1 | PATCH | Ensure password creation requirements are configured | Set retry to 3 if pwquality exists"
@@ -615,12 +616,14 @@
   command: /bin/true
   changed_when: false
   failed_when: false
+  check_mode: false
   # block:
   #     - name: "5.3.2 | AUDIT | Ensure lockout for failed password attempts is configured | Confirm pam_tally2.so module in common-auth"
   #       # command: grep 'auth.*required.*pam_tally2.so' /etc/pam.d/common-auth
   #       command: grep 'auth.*required.*pam_tally2.so' /etc/pam.d/common-account
   #       changed_when: false
   #       failed_when: false
+  #       check_mode: false
   #       register: ubtu20cis_5_3_2_pam_tally2_state
 
   #     - name: "SCORED | 5.3.2 | PATCH | Ensure lockout for failed password attempts is configured | Set pam_tally2.so settings if exists"
@@ -672,6 +675,7 @@
         command: grep 'password.*required.*pam_pwhistory.so' /etc/pam.d/common-password
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_5_3_3_pam_pwhistory_state
 
       - name: "5.3.3 | PATCH | Ensure password reuse is limited | Set remember value if pam_pwhistory exists"
@@ -705,6 +709,7 @@
         shell: grep -E '^\s*password\s+(\S+\s+)+pam_unix\.so\s+(\S+\s+)*sha512\s*(\S+\s*)*(\s+#.*)?$' /etc/pam.d/common-password
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_5_3_4_pam_unix_state
 
       - name: "5.3.4 | PATCH | Ensure password hashing algorithm is SHA-512 | Set hashing if pam_unix.so exists"
@@ -833,12 +838,14 @@
         shell: echo $(($(date --utc --date "$1" +%s)/86400))
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_5_4_1_5_current_time
 
       - name: "5.4.1.5 | PATCH | Ensure all users last password change date is in the past | Get list of users with last changed PW date in future"
         shell: "cat /etc/shadow | awk -F: '{if($3>{{ ubtu20cis_5_4_1_5_current_time.stdout }})print$1}'"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_5_4_1_5_user_list
 
       - name: "5.4.1.5 | PATCH | Ensure all users last password change date is in the past | Warn about users"
@@ -926,6 +933,7 @@
         shell: grep -E '^session.*optional.*pam_umask.so' /etc/pam.d/common-session
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_5_4_4_umask_pam_status
 
       - name: "5.4.4 | PATCH | Ensure default user umask is 027 or more restrictive"
@@ -984,6 +992,7 @@
         command: cat /etc/securetty
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_5_5_terminal_list
 
       - name: "5.5 | AUDIT | Ensure root login is restricted to system console | Message out list"
@@ -1008,6 +1017,7 @@
         command: grep 'auth.*required.*pam_wheel' /etc/pam.d/su
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_5_6_pam_wheel_status
 
       - name: "5.6 | PATCH | Ensure access to the su command is restricted | Create empty sugroup"

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -5,12 +5,14 @@
         command: ls -a /bin/
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_1_1_packages
 
       # - name: "NOTSCORED | 6.1.1 | AUDIT | Audit system file permissions | Audit the packages"
       #   command: dpkg --verify {{ item }}
       #   changed_when: false
       #   failed_when: false
+      #   check_mode: false
       #   with_items:
       #       - "{{ ubtu18cis_6_1_1_packages.stdout_lines }}"
       #   register: ubtu18cis_6_1_1_packages_audited
@@ -157,6 +159,7 @@
         shell: find {{ item.mount }} -xdev -type f -perm -0002
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_1_10_wwf
         with_items:
             - "{{ ansible_mounts }}"
@@ -183,6 +186,7 @@
         shell: find {{ item.mount }} -xdev -nouser
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_1_11_no_user_items
         with_items:
             - "{{ ansible_mounts }}"
@@ -225,6 +229,7 @@
         shell: find {{ item.mount }} -xdev -nogroup
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_1_12_ungrouped_items
         with_items:
             - "{{ ansible_mounts }}"
@@ -268,6 +273,7 @@
         shell: find {{ item.mount }} -xdev -type f -perm -4000
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_1_13_suid_executables
         with_items:
             - "{{ ansible_mounts }}"
@@ -311,6 +317,7 @@
         shell: find {{ item }} -xdev -type f -perm -2000
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_1_14_sgid_executables
         with_items:
             - "{{ ansible_mounts }}"
@@ -342,7 +349,7 @@
         shell: awk -F":" '($2 == "" ) { print $1 }' /etc/shadow
         register: ubtu20cis_6_2_1_empty_password_acct
         changed_when: no
-        check_mode: no
+        check_mode: false
 
       - name: "6.2.1 | PATCH | Ensure password fields are not empty | Lock users with empty password"
         user:
@@ -367,6 +374,7 @@
         shell: awk -F":" '($3 == 0 && $1 != \"root\") {i++;print $1 }' /etc/passwd
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_2_2_uid_0_notroot
 
       - name: "6.2.2 | PATCH | Ensure root is the only UID 0 account | Lock UID 0 users"
@@ -412,29 +420,34 @@
   command: /bin/true
   changed_when: false
   failed_when: false
+  check_mode: false
   # block:
   #     - name: "6.2.3 | PATCH | Ensure root PATH Integrity | Determine empty value"
   #       shell: 'echo $PATH | grep ::'
   #       changed_when: False
   #       failed_when: ubtu20cis_6_2_3_path_colon.rc == 0
+  #       check_mode: false
   #       register: ubtu20cis_6_2_3_path_colon
 
   #     - name: "6.2.3 | PATCH | Ensure root PATH Integrity | Determine colon end"
   #       shell: 'echo $PATH | grep :$'
   #       changed_when: False
   #       failed_when: ubtu20cis_6_2_3_path_colon_end.rc == 0
+  #       check_mode: false
   #       register: ubtu20cis_6_2_3_path_colon_end
 
   #     - name: "6.2.3 | PATCH | Ensure root PATH Integrity | Determine working dir"
   #       shell: echo "$PATH"
   #       changed_when: False
   #       failed_when: '"." in ubtu20cis_6_2_3_working_dir.stdout_lines'
+  #       check_mode: false
   #       register: ubtu20cis_6_2_3_working_dir
   #     - debug: var=ubtu20cis_6_2_3_working_dir
 
   #     - name: "6.2.3 | PATCH | Ensure root PATH Integrity | Check paths"
   #       stat:
   #           path: "{{ item }}"
+  #       check_mode: false
   #       register: ubtu20cis_6_2_3_path_stat
   #       with_items:
   #           - "{{ ubtu20cis_6_2_3_working_dir.stdout.split(':') }}"
@@ -472,7 +485,7 @@
         block: &u20s_homedir_audit
             - name: "6.2.4 | PATCH | Ensure all users' home directories exist | Find users missing home directories"
               shell: pwck -r | grep -P {{ ld_regex | quote }}
-              check_mode: no
+              check_mode: false
               register: ubtu20cis_users_missing_home
               changed_when: ubtu20cis_6_2_4_audit | length > 0
               # failed_when: 0: success, 1: no grep match, 2: pwck found something
@@ -520,12 +533,14 @@
         stat:
             path: "{{ item }}"
         with_items: "{{ ubtu20cis_passwd | selectattr('uid', '>=', 1000) | selectattr('uid', '!=', 65534) | map(attribute='dir') | list }}"
+        check_mode: false
         register: ubtu20cis_6_2_5_audit
 
       - name: "6.2.5 | AUDIT | Ensure users' home directories permissions are 750 or more restrictive | Find home directories more 750"
         command: find -H {{ item.0 | quote }} -not -type l -perm /027
         register: ubtu20cis_6_2_4_patch_audit
         changed_when: ubtu20cis_6_2_4_patch_audit.stdout != ""
+        check_mode: false
         when:
             - item.1.exists
         with_together:
@@ -602,6 +617,7 @@
         shell: find /home/ -name "\.*" -perm /g+w,o+w
         changed_when: no
         failed_when: no
+        check_mode: false
         register: ubtu20cis_6_2_7_audit
 
       - name: "6.2.7 | AUDIT | Ensure users' dot files are not group or world-writable | Alert on files found"
@@ -701,6 +717,7 @@
         shell: pwck -r | grep 'no group' | awk '{ gsub("[:\47]",""); print $2}'
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_2_12_passwd_gid_check
 
       - name: "6.2.12 | AUDIT | Ensure all groups in /etc/passwd exist in /etc/group | Print message that all groups match between passwd and group files"
@@ -727,6 +744,7 @@
         shell: "pwck -r | awk -F: '{if ($3 in uid) print $1 ; else uid[$3]}' /etc/passwd"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_2_13_user_uid_check
 
       - name: "6.2.13 | AUDIT | Ensure no duplicate UIDs exist | Print message that no duplicate UIDs exist"
@@ -753,6 +771,7 @@
         shell: "pwck -r | awk -F: '{if ($3 in users) print $1 ; else users[$3]}' /etc/group"
         changed_when: no
         failed_when: no
+        check_mode: false
         register: ubtu20cis_6_2_14_user_user_check
 
       - name: "6.2.14 | AUDIT | Ensure no duplicate GIDs exist | Print message that no duplicate GID's exist"
@@ -779,6 +798,7 @@
         shell: "pwck -r | awk -F: '{if ($1 in users) print $1 ; else users[$1]}' /etc/passwd"
         changed_when: no
         failed_when: no
+        check_mode: false
         register: ubtu20cis_6_2_15_user_username_check
 
       - name: "6.2.15 | AUDIT | Ensure no duplicate user names exist | Print message that no duplicate user names exist"
@@ -805,6 +825,7 @@
         shell: 'getent passwd | cut -d: -f1 | sort -n | uniq -d'
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_2_16_group_group_check
 
       - name: "6.2.16 | AUDIT | Ensure no duplicate group names exist | Print message that no duplicate groups exist"
@@ -831,12 +852,14 @@
         shell: grep ^shadow /etc/group | cut -f3 -d":"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_2_17_shadow_gid
 
       - name: "6.2.17 | AUDIT | Ensure shadow group is empty | List of users with Shadow GID"
         shell: awk -F":" '($4 == "{{ ubtu20cis_6_2_17_shadow_gid.stdout }}") { print }' /etc/passwd | cut -f1 -d":"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: ubtu20cis_6_2_17_users_shadow_gid
 
       - name: "6.2.17 | AUDIT | Ensure shadow group is empty | Message on no users"


### PR DESCRIPTION
I've fixed all the errors caused by undefined variables in check mode. I.e. now you can run
```shell
$ ansible-playbook -i inventory site.yml -C
```
and get a reasonable overview of what would be changed. 
I tested only with the default variable settings.  But I believe I got pretty much all of the cases.
Even the tasks in the commented out code where that would obviously be needed.

This was mostly adding "check_mode: false" to all the information gathering tasks.

The gather_subset in main/tasks.yml needed expanding too, because ansible_mounts, ansible_virtualization_type, and ansible_architecture weren't being defined.

This is with:
```shell
ansible --version
ansible 2.10.7
```