### PR TITLE
gdm3: trim newlines from ubtu20cis_warning_banner

### DIFF
--- a/tasks/section_1/cis_1.8.x.yml
+++ b/tasks/section_1/cis_1.8.x.yml
@@ -28,7 +28,7 @@
   with_items:
       - { regexp: '\[org\/gnome\/login-screen\]', line: '[org/gnome/login-screen]', insertafter: EOF }
       - { regexp: 'banner-message-enable', line: 'banner-message-enable=true', insertafter: '\[org\/gnome\/login-screen\]'}
-      - { regexp: 'banner-message-text', line: 'banner-message-text={{ ubtu20cis_warning_banner }}', insertafter: 'banner-message-enable' }
+      - { regexp: 'banner-message-text', line: "banner-message-text='{{ ubtu20cis_warning_banner | regex_replace('\n', ' ') | trim }}'", insertafter: 'banner-message-enable' } # NB: must strip newlines
   when:
       - ubtu20cis_rule_1_8_2
       - ubtu20cis_desktop_required


### PR DESCRIPTION
banner-message-text must be a single line.

Signed-off-by: Christoph Badura <bad@bsd.de>

**Overall Review of Changes:**
banner-message-text must be a single line string.
Convert newlines to spaces and trim leading and trailing whitespace from ubtu20cis_warning_banner.
Put the value in single quotes.

**Enhancements:**
As above.

**How has this been tested?:**
Manually
