### PR TITLE
gather_subset: replace 'hardware' with 'mounts'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,11 @@
 # - debug: var=ansible_facts
 - name: Gather distribution info
   # we need:
-  # - hardware for ansible_mounts
+  # - mounts for ansible_mounts
   # - platform for ansible_architecture (ansible internal)
   # - virtual for ansible_virtualization_type
   setup:
-      gather_subset: distribution,hardware,platform,virtual,!all,!min
+      gather_subset: distribution,mounts,platform,virtual,!all,!min
   when:
       - ansible_distribution is not defined
   tags:


### PR DESCRIPTION
the latter is sufficient to fill ansible_mounts.

Signed-off-by: Christoph Badura <bad@bsd.de>

**Overall Review of Changes:**
we don't need to gather the full hardware details to establish the list of mounted file systems.

**How has this been tested?:**
Manually.