### PR TITLE
rule 1.9: must "apt update" beforehand

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -3,7 +3,8 @@
   apt:
       update_cache: yes
   when:
-      - ubtu20cis_rule_1_3_1
+      - ubtu20cis_rule_1_3_1 or
+        ubtu20cis_rule_1_9
 
 - name: "PRELIM | Check for autofs service"
   shell: "systemctl show autofs | grep LoadState | cut -d = -f 2"


### PR DESCRIPTION
otherwise we act on stale package versions.

Signed-off-by: Christoph Badura <bad@bsd.de>

**Overall Review of Changes:**
run prelim task "PRELIM | Run apt update" for rule 1.9 too, so that we work against the latest available packages.

**How has this been tested?:**
Manually.