### PR TITLE
rule 3.5.1.5: remove incorrect "to_port: all"

### DIFF
--- a/tasks/section_3/cis_3.5.x.yml
+++ b/tasks/section_3/cis_3.5.x.yml
@@ -104,7 +104,6 @@
         ufw:
             rule: allow
             direction: out
-            to_port: all
         notify: reload ufw
         when: "'all' in ubtu20cis_ufw_allow_out_ports"
   when:


### PR DESCRIPTION
the ufw module does not allow "to_port: all".

Signed-off-by: Christoph Badura <bad@bsd.de>

**Overall Review of Changes:**
Do not pass "to_port: all" to the ufw module.  It doesn't accept it.
When no "to_port:" parameter is passed, it allows all ports as destination ports.

**How has this been tested?:**
Manually.