### PR TITLE
rules 6.1.10-6.1.14: skip NFS mounted file systems

### DIFF
--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -170,7 +170,7 @@
         check_mode: false
         register: ubtu20cis_6_1_10_wwf
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_mounts | selectattr('fstype', '!=', 'nfs') }}"
 
       - name: "AUTOMATED | 6.1.10 | PATCH | Ensure no world writable files exist | Adjust world-writable files if they exist"
         file:
@@ -198,7 +198,7 @@
         check_mode: false
         register: ubtu20cis_6_1_11_no_user_items
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_mounts | selectattr('fstype', '!=', 'nfs') }}"
 
       - name: "AUTOMATED | 6.1.11 | AUDIT | Ensure no unowned files or directories exist | Flatten no_user_items results for easier use"
         set_fact:
@@ -242,7 +242,7 @@
         check_mode: false
         register: ubtu20cis_6_1_12_ungrouped_items
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_mounts | selectattr('fstype', '!=', 'nfs') }}"
 
       - name: "AUTOMATED | 6.1.12 | AUDIT | Ensure no ungrouped files or directories exist | Flatten ungrouped_items results for easier use"
         set_fact:
@@ -287,7 +287,7 @@
         check_mode: false
         register: ubtu20cis_6_1_13_suid_executables
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_mounts | selectattr('fstype', '!=', 'nfs') }}"
 
       - name: "MANUAL | 6.1.13 | AUDIT | Audit SUID executables | Flatten suid_executables results for easier use"
         set_fact:
@@ -331,7 +331,7 @@
         check_mode: false
         register: ubtu20cis_6_1_14_sgid_executables
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_mounts | selectattr('fstype', '!=', 'nfs') }}"
 
       - name: "MANUAL | 6.1.14 | AUDIT | Audit SGID executables | Flatten sgid_executables results for easier use"
         set_fact:


### PR DESCRIPTION
they are potentially huge and slow.

Signed-off-by: Christoph Badura <bad@bsd.de>

**Overall Review of Changes:**
Do not descend into nfs mounted file systems when looking for unowned, ungrouped, setuid etc. files.

**How has this been tested?:**
Manually.
