### PR TITLE
prelim.yml: fix condition for installation of acl pkg

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -39,7 +39,7 @@
       state: present
   when:
       - ubtu20cis_rule_6_2_6
-      - ubtu20cis_install_network_manager
+      - not ubtu20cis_system_is_container
 
 - name: "PRELIM | List users accounts"
   command: "awk -F: '{print $1}' /etc/passwd"


### PR DESCRIPTION
this isn't dependent on ubtu20cis_install_network_manager.
rather it is dependent on "not ubtu20cis_system_is_container".

Signed-off-by: Christoph Badura <bad@bsd.de>

**Overall Review of Changes:**
Fix the when: condition on the task.

**How has this been tested?:**
Manually.
