### PR TITLE
rule 2.2.6: do not remove rpcbind if nfs client or server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -345,6 +345,7 @@ ubtu20cis_cups_server: false
 ubtu20cis_dhcp_server: false
 ubtu20cis_ldap_server: false
 ubtu20cis_nfs_server: false
+ubtu20cis_nfs_client: false
 ubtu20cis_dns_server: false
 ubtu20cis_vsftpd_server: false
 ubtu20cis_httpd_server: false
@@ -354,7 +355,8 @@ ubtu20cis_squid_server: false
 ubtu20cis_snmp_server: false
 ubtu20cis_rsync_server: false
 ubtu20cis_nis_server: false
-ubtu20cis_rpc_required: false
+# rpcbind is required by nfs-common which is required on client and server
+ubtu20cis_rpc_required: "{{ ubtu20cis_nfs_server or ubtu20cis_nfs_client }}"
 
 # Clients in use variables
 ubtu20cis_nis_required: false


### PR DESCRIPTION
this introduces the variable ubtu20cis_nfs_client defaulting to false and
initializes ubtu20cis_rpc_required differently.

This needs an update in the wiki for the new variable.

Signed-off-by: Christoph Badura <bad@bsd.de>

**Overall Review of Changes:**
rpcbind is required by nfs-common which is required on nfs client and server.

**How has this been tested?:**
Manually.
