### PR TITLE
rule 5.5.5: only set TMOUT if it isn't set yet

### DIFF
--- a/tasks/section_5/cis_5.5.x.yml
+++ b/tasks/section_5/cis_5.5.x.yml
@@ -246,7 +246,8 @@
       marker: "# {mark} ANSIBLE MANAGED"
       block: |
         # Set session timeout - CIS ID 5.5.5
-        TMOUT={{ ubtu20cis_shell_session_timeout.timeout }}
+        # only set TMOUT if it isn't set yet to avoid a shell error
+        : ${TMOUT={{ ubtu20cis_shell_session_timeout.timeout }}}
         readonly TMOUT
         export TMOUT
   with_items:


### PR DESCRIPTION
avoids an error message from bash when TMOUT was already set in a different
startup file.

Signed-off-by: Christoph Badura <bad@bsd.de>

**Overall Review of Changes:**
The way it is currently implemented TMOUT is set in multiple bash startup files and reassigned during shell initialization.  This causes errors processing the later startup files because readonly variables can't be assigned to.

**How has this been tested?:**
Manually.