### PR TITLE
Unofficial Ubuntu 22.04 support e.a.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -304,7 +304,7 @@ ubtu20cis_rule_5_6: true
 ubtu20cis_rule_5_7: true
 
 # Section 6 Fixes
-# Section is Systme Maintenance (System File Permissions and User and Group Settings)
+# Section is System Maintenance (System File Permissions and User and Group Settings)
 ubtu20cis_rule_6_1_1: true
 ubtu20cis_rule_6_1_2: true
 ubtu20cis_rule_6_1_3: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
   when:
       - ansible_distribution == 'Ubuntu'
       - ansible_distribution_major_version is version_compare('20', '!=')
+      - ansible_distribution_major_version is version_compare('22', '!=')
   tags:
       - always
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -32,6 +32,7 @@
       state: present
   when:
       - ubtu20cis_rule_3_1_2
+      - ubtu20cis_install_network_manager
       - not ubtu20cis_system_is_container
 
 - name: "PRELIM | Install ACL"
@@ -40,7 +41,6 @@
       state: present
   when:
       - ubtu20cis_rule_6_2_6
-      - ubtu20cis_install_network_manager
 
 - name: "PRELIM | List users accounts"
   command: "awk -F: '{print $1}' /etc/passwd"

--- a/tasks/section_1/cis_1.5.x.yml
+++ b/tasks/section_1/cis_1.5.x.yml
@@ -36,6 +36,7 @@
         sysctl:
             name: kernel.randomize_va_space
             value: '2'
+            sysctl_file: "/etc/sysctl.d/10-kernel-hardening.conf"
   when:
       - ubtu20cis_rule_1_5_2
   tags:
@@ -77,6 +78,7 @@
             state: present
             reload: yes
             sysctl_set: yes
+            sysctl_file: "/etc/sysctl.d/10-kernel-hardening.conf"
             ignoreerrors: yes
 
       - name: "AUTOMATED | 1.5.4 | PATCH | Ensure core dumps are restricted | security limits"

--- a/tasks/section_1/main.yml
+++ b/tasks/section_1/main.yml
@@ -2,10 +2,10 @@
 - name: "SECTION | 1.1 | Disable Unused Filesystems"
   include: cis_1.1.x.yml
 
-- name: "SECTION | 1.2 | Cofnigure Software Updates"
+- name: "SECTION | 1.2 | Configure Software Updates"
   include: cis_1.2.x.yml
 
-- name: "SECTION | 1.3. | Filesystem Integrity Checking"
+- name: "SECTION | 1.3 | Filesystem Integrity Checking"
   include: cis_1.3.x.yml
 
 - name: "SECTION | 1.4 | Secure Boot Settings"

--- a/tasks/section_3/cis_3.3.x.yml
+++ b/tasks/section_3/cis_3.3.x.yml
@@ -6,6 +6,7 @@
             name: "{{ item }}"
             value: '0'
             sysctl_set: yes
+            sysctl_file: "/etc/sysctl.d/10-network-security.conf"
             state: present
             reload: yes
             ignoreerrors: yes
@@ -19,6 +20,7 @@
             name: "{{ item }}"
             value: '0'
             sysctl_set: yes
+            sysctl_file: "/etc/sysctl.d/10-network-security.conf"
             state: present
             reload: yes
             ignoreerrors: yes
@@ -46,6 +48,7 @@
             name: "{{ item }}"
             value: '0'
             sysctl_set: yes
+            sysctl_file: "/etc/sysctl.d/10-network-security.conf"
             state: present
             reload: yes
             ignoreerrors: yes
@@ -59,6 +62,7 @@
             name: "{{ item }}"
             value: '0'
             sysctl_set: yes
+            sysctl_file: "/etc/sysctl.d/10-network-security.conf"
             state: present
             reload: yes
             ignoreerrors: yes
@@ -83,6 +87,7 @@
       name: "{{ item }}"
       value: '0'
       sysctl_set: yes
+      sysctl_file: "/etc/sysctl.d/10-network-security.conf"
       state: present
       reload: yes
       ignoreerrors: yes
@@ -106,6 +111,7 @@
       name: "{{ item }}"
       value: '1'
       sysctl_set: yes
+      sysctl_file: "/etc/sysctl.d/10-network-security.conf"
       state: present
       reload: yes
       ignoreerrors: yes
@@ -129,6 +135,7 @@
       name: net.ipv4.icmp_echo_ignore_broadcasts
       value: '1'
       sysctl_set: yes
+      sysctl_file: "/etc/sysctl.d/10-network-security.conf"
       state: present
       reload: yes
       ignoreerrors: yes
@@ -149,6 +156,7 @@
       name: net.ipv4.icmp_ignore_bogus_error_responses
       value: '1'
       sysctl_set: yes
+      sysctl_file: "/etc/sysctl.d/10-network-security.conf"
       state: present
       reload: yes
       ignoreerrors: yes
@@ -169,6 +177,7 @@
       name: "{{ item }}"
       value: '1'
       sysctl_set: yes
+      sysctl_file: "/etc/sysctl.d/10-network-security.conf"
       state: present
       reload: yes
       ignoreerrors: yes
@@ -192,6 +201,7 @@
       name: net.ipv4.tcp_syncookies
       value: '1'
       sysctl_set: yes
+      sysctl_file: "/etc/sysctl.d/10-network-security.conf"
       state: present
       reload: yes
       ignoreerrors: yes
@@ -212,6 +222,7 @@
       name: "{{ item }}"
       value: '0'
       sysctl_set: yes
+      sysctl_file: "/etc/sysctl.d/10-network-security.conf"
       state: present
       reload: yes
       ignoreerrors: yes


### PR DESCRIPTION
**Overall Review of Changes:**
* Add unofficial support for Ubuntu 22.04. While an official CIS for Ubuntu 22.04 hasn't been published yet, there are very little fundamental differences between 20.04 and 22.04.
* Change sysctl settings to be set in specific folders. Instead of dumping all the settings in the main file, use the sysctl.d subfolder and place the sysctl settings in their respective folders.
* The check for NetworkManager is applied to the wrong task, move it to the correct one.
* Fix some typo's

**How has this been tested?:**
* I've run this role against my own Ubuntu 22.04 installation, without rsyslog, without firewall and with systemd-timesyncd als NTP.
