### PR TITLE
Remove redundant code. #63

### DIFF
--- a/tasks/parse_etc_password.yml
+++ b/tasks/parse_etc_password.yml
@@ -10,8 +10,6 @@
       - name: "PRELIM | {{ ubtu20cis_passwd_tasks }} | Split passwd entries"
         set_fact:
             ubtu20cis_passwd: "{{ ubtu20cis_passwd_file_audit.stdout_lines | map('regex_replace', ld_passwd_regex, ld_passwd_yaml) | map('from_yaml') | list }}"
-
-        with_items: "{{ ubtu20cis_passwd_file_audit.stdout_lines }}"
         vars:
             ld_passwd_regex: >-
                 ^(?P<id>[^:]*):(?P<password>[^:]*):(?P<uid>[^:]*):(?P<gid>[^:]*):(?P<gecos>[^:]*):(?P<dir>[^:]*):(?P<shell>[^:]*)


### PR DESCRIPTION
**Overall Review of Changes:**
Enhancement #63
Remove redundant loop from tasks/parse_etc_password.yml. 

**Issue Fixes:**

**Enhancements:**
#63

**How has this been tested?:**
See PR #64

Result:
```yaml
  msg: '[OK]  parse_etc_password: Parsed.'
```
