### PR TITLE
Use jc to parse /etc/passwd. #63

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -6,3 +6,5 @@ collections:
 - name: community.crypto
   
 - name:  ansible.posix
+
+- name:  ansible.utils

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -713,8 +713,8 @@ setup_python_pkg:
   - jc
 
 # Ubuntu packages on the control node
-setup_ubuntu_pkg:
-  - python3-passlib
-  - python3-lxml
-  - python3-xmltodict
-  - python3-jmespath
+setup_ubuntu_pkg: []
+#  - python3-passlib
+#  - python3-lxml
+#  - python3-xmltodict
+#  - python3-jmespath

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -704,3 +704,17 @@ audit_results: |
       The pre remediation results are: {{ pre_audit_summary }}.
       The post remediation results are: {{ post_audit_summary }}.
       Full breakdown can be found in {{ audit_out_dir }}
+
+
+#### Setup. Configuration of the control node ####
+
+# Python packages on the control node
+setup_python_pkg:
+  - jc
+
+# Ubuntu packages on the control node
+setup_ubuntu_pkg:
+  - python3-passlib
+  - python3-lxml
+  - python3-xmltodict
+  - python3-jmespath

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,5 +24,6 @@ collections:
     - community.general
     - community.crypto
     - ansible.posix
+    - ansible.utils
 
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,11 @@
   tags:
       - always
 
+- import_tasks: setup.yml
+  when: ubtu20cis_setup_enable|default(true)|bool
+  tags:
+      - setup
+
 - import_tasks: prelim.yml
   tags:
       - prelim_tasks

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
       - always
 
 - import_tasks: setup.yml
-  when: ubtu20cis_setup_enable|default(true)|bool
+  when: ubtu20cis_setup_enable|d(true)|bool
   tags:
       - setup
 

--- a/tasks/parse_etc_password.yml
+++ b/tasks/parse_etc_password.yml
@@ -1,32 +1,21 @@
 ---
-- name: "PRELIM | {{ ubtu20cis_passwd_tasks }} | Parse /etc/passwd"
+- name: "PRELIM | {{ ubtu20cis_passwd_tasks }} | Parse {{ cis_etc_passwd_file }}"
   block:
-      - name: "PRELIM | {{ ubtu20cis_passwd_tasks }} | Parse /etc/passwd"
-        command: cat /etc/passwd
+      - name: "PRELIM | {{ ubtu20cis_passwd_tasks }} | Parse {{ cis_etc_passwd_file }}"
+        command: "cat {{ cis_etc_passwd_file }}"
         changed_when: false
         check_mode: false
         register: ubtu20cis_passwd_file_audit
 
       - name: "PRELIM | {{ ubtu20cis_passwd_tasks }} | Split passwd entries"
         set_fact:
-            ubtu20cis_passwd: "{{ ubtu20cis_passwd_file_audit.stdout_lines | map('regex_replace', ld_passwd_regex, ld_passwd_yaml) | map('from_yaml') | list }}"
-
-        with_items: "{{ ubtu20cis_passwd_file_audit.stdout_lines }}"
+            ubtu20cis_passwd: "{{ ubtu20cis_passwd_file_audit.stdout|
+                                  community.general.jc('passwd')|from_yaml|
+                                  ansible.utils.replace_keys(target=cis_etc_passwd_keys) }}"
         vars:
-            ld_passwd_regex: >-
-                ^(?P<id>[^:]*):(?P<password>[^:]*):(?P<uid>[^:]*):(?P<gid>[^:]*):(?P<gecos>[^:]*):(?P<dir>[^:]*):(?P<shell>[^:]*)
-            ld_passwd_yaml: |
-                id: >-4
-                    \g<id>
-                password: >-4
-                    \g<password>
-                uid: \g<uid>
-                gid: \g<gid>
-                gecos: >-4
-                    \g<gecos>
-                dir: >-4
-                    \g<dir>
-                shell: >-4
-                    \g<shell>
+            cis_etc_passwd_keys:
+              - {before: comment, after: gecos}
+              - {before: home, after: dir}
+              - {before: username, after: id}
   tags:
       - always

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,0 +1,14 @@
+---
+- name: "SETUP | Install Ubuntu packages on control node"
+  apt:
+      update_cache: yes
+      name: "{{ setup_ubuntu_pkg }}"
+  run_once: true
+  delegate_to: localhost
+
+- name: "SETUP | Install Python packages on control node"
+  pip:
+      name: "{{ setup_python_pkg }}"
+  run_once: true
+  delegate_to: localhost
+  become: false

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,16 +1,29 @@
 ---
+- name: "SETUP | List installed packages on control node"
+  block:
+      - name: "SETUP | Collect installed packages on control node"
+        package_facts:
+            strategy: all
+      - name: "SETUP | Display installed packages on control node"
+        debug:
+            var: ansible_facts.packages
+  when: ubtu20cis_setup_list|d(false)|bool
+  delegate_to: localhost
+  run_once: true
+  become: true
+
 - name: "SETUP | Install Ubuntu packages on control node"
   apt:
       update_cache: yes
       name: "{{ setup_ubuntu_pkg }}"
   when: setup_ubuntu_pkg|length > 0
-  run_once: true
   delegate_to: localhost
+  run_once: true
   become: true
 
 - name: "SETUP | Install Python packages on control node"
   pip:
       name: "{{ setup_python_pkg }}"
-  run_once: true
   delegate_to: localhost
-  become: false
+  run_once: true
+  become: true

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -5,6 +5,7 @@
       name: "{{ setup_ubuntu_pkg }}"
   run_once: true
   delegate_to: localhost
+  become: true
 
 - name: "SETUP | Install Python packages on control node"
   pip:

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -3,6 +3,7 @@
   apt:
       update_cache: yes
       name: "{{ setup_ubuntu_pkg }}"
+  when: setup_ubuntu_pkg|length > 0
   run_once: true
   delegate_to: localhost
   become: true

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -24,6 +24,7 @@
 - name: "SETUP | Install Python packages on control node"
   pip:
       name: "{{ setup_python_pkg }}"
+      extra_args: --user
   delegate_to: localhost
   run_once: true
-  become: true
+  become: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for UBUNTU20-CIS
+
+cis_etc_passwd_file: /etc/passwd


### PR DESCRIPTION
**Overall Review of Changes:**
Simplify the code. Use filter *community.general.jc* to parse /etc/passwd. Use filter *ansible.utils.replace_keys* to rename keys.

**Issue Fixes:**
No issues.

**Enhancements:**
#63

**How has this been tested?:**
See PR #64 

Result

```yaml
msg: '[OK]  parse_etc_password: Parsed.'
```
