### PR TITLE
Installing chrony removes systemd timesyncd

### DIFF
--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -75,6 +75,7 @@
             state: stopped
             enabled: false
             masked: true
+        when: "'systemd-timesyncd' in ansible_facts.packages"
 
       - name: "2.1.1.3 | AUDIT | Ensure chrony is configured | Check for chrony user"
         ansible.builtin.shell: grep {{ ubtu20cis_chrony_user }} /etc/passwd


### PR DESCRIPTION
**Overall Review of Changes:**
Removes check of systemd-timesyncd when chrony is the configured time source

**Issue Fixes:**
#78

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Used to configure an Ubuntu 20 test server. The step which previously failed (because systemd-timesyncd cannot be installed if chrony is) now runs successfully.