### PR TITLE
#73 fix thanks to @fnschroeder

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -58,6 +58,7 @@
       name: network-manager
       state: present
   when:
+      - wireless_interfaces.stdout is defined
       - wireless_interfaces.stdout | length > 0
       - ubtu20cis_install_network_manager
       - ubtu20cis_rule_3_1_2


### PR DESCRIPTION
**Overall Review of Changes:**
Fix for wifi install net-work manager verified working by @fnschroeder this was never merged into devel or main after repo was created in March.

**Issue Fixes:**
#73 https://github.com/ansible-lockdown/UBUNTU20-CIS/issues/73

**Enhancements:**
n/a

**How has this been tested?:**
locally
