### PR TITLE
adds feature to allow rsync install CIS compliant

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -415,7 +415,7 @@ ubtu20cis_dovecot_server: false
 ubtu20cis_smb_server: false
 ubtu20cis_squid_server: false
 ubtu20cis_snmp_server: false
-ubtu20cis_rsync_server: false
+ubtu20cis_rsync_server: mask  # Can be set to true, mask or remove depending on requirements
 ubtu20cis_nis_server: false
 ubtu20cis_nfs_client: false
 # rpcbind is required by nfs-common which is required on client and server

--- a/tasks/section_2/cis_2.2.x.yml
+++ b/tasks/section_2/cis_2.2.x.yml
@@ -328,13 +328,26 @@
       - rule_2.2.16
       - postfix
 
-- name: "2.2.17 | PATCH | Ensure rsync service is not installed"
-  ansible.builtin.package:
-      name: rsync
-      state: absent
+- name: "2.2.17 | PATCH | Ensure rsync service is either not installed or masked"
+  block:
+    - name: "2.2.17 | PATCH | Ensure rsync service is either not installed or masked | remove pkg"
+      ansible.builtin.package:
+          name: rsync
+          state: absent
+      when:
+          - ubtu20cis_rule_2_2_17
+          - ubtu20cis_rsync_server == 'remove'
+
+    - name: "2.2.17 | PATCH | Ensure rsync service is either not installed or masked | mask service"
+      ansible.builtin.service:
+          name: rsync.service
+          state: stopped
+          enabled: false
+          masked: true
+      when:
+          - ubtu20cis_rule_2_2_17
+          - ubtu20cis_rsync_server == 'mask'
   when:
-      - ubtu20cis_rule_2_2_17
-      - not ubtu20cis_rsync_server
       - "'rsync' in ansible_facts.packages"
   tags:
       - level1-server


### PR DESCRIPTION
**Overall Review of Changes:**
Adds switch to allow rsync to remain installed and CIS compliant.  CIS control allows rsync pkg installed with service masked

**Issue Fixes:**

**Enhancements:**
use ubtu20cis_rsync_masked: true to leave rsync installed and mask/disable the service

**How has this been tested?:**
tested locally
