### PR TITLE
1.4.3 uses wrong var for hash

### DIFF
--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -63,7 +63,7 @@
 - name: "1.4.3 | PATCH | Ensure authentication required for single user mode"
   ansible.builtin.user:
       name: "{{ ubtu20cis_grub_user }}"
-      password: "{{ ubtu20cis_bootloader_password_hash }}"
+      password: "{{ ubtu20cis_root_pw }}"
   when:
       - ubtu20cis_rule_1_4_3
       - ubtu20cis_set_boot_pass


### PR DESCRIPTION
**Overall Review of Changes:**
found a typo using wrong var for p/w hash
**Issue Fixes:**
root p/w gets clobbered no more

**Enhancements:**
n/a
**How has this been tested?:**
tested locally
