### PR TITLE
updated to use sleep variable and lint

### DIFF
--- a/.github/workflows/devel_pipeline_validation.yml
+++ b/.github/workflows/devel_pipeline_validation.yml
@@ -44,13 +44,13 @@
 
           steps:
             - name: Clone ${{ github.event.repository.name }}
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 ref: ${{ github.event.pull_request.head.sha }}
 
             # Pull in terraform code for linux servers
             - name: Clone github IaC plan
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 repository: ansible-lockdown/github_linux_IaC
                 path: .github/workflows/github_linux_IaC
@@ -111,7 +111,7 @@
       # Aws deployments taking a while to come up insert sleep or playbook fails
 
             - name: Sleep for 60 seconds
-              run: sleep 60s
+              run: sleep ${{ vars.BUILD_SLEEPTIME }}
 
           # Run the ansible playbook
             - name: Run_Ansible_Playbook

--- a/.github/workflows/main_pipeline_validation.yml
+++ b/.github/workflows/main_pipeline_validation.yml
@@ -33,13 +33,13 @@
 
           steps:
             - name: Clone ${{ github.event.repository.name }}
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 ref: ${{ github.event.pull_request.head.sha }}
 
             # Pull in terraform code for linux servers
             - name: Clone github IaC plan
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 repository: ansible-lockdown/github_linux_IaC
                 path: .github/workflows/github_linux_IaC
@@ -100,7 +100,7 @@
       # Aws deployments taking a while to come up insert sleep or playbook fails
 
             - name: Sleep for 60 seconds
-              run: sleep 60s
+              run: sleep ${{ vars.BUILD_SLEEPTIME }}
 
           # Run the ansible playbook
             - name: Run_Ansible_Playbook

--- a/.github/workflows/update_galaxy.yml
+++ b/.github/workflows/update_galaxy.yml
@@ -6,7 +6,7 @@ name: update galaxy
 
 # Controls when the action will run.
 # Triggers the workflow on merge request events to the main branch
-on:
+on:  # yamllint disable-line rule:truthy
     push:
         branches:
             - main
@@ -14,8 +14,10 @@ jobs:
     update_role:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: robertdebock/galaxy-action@master
+            - name: Checkout repo
+              uses: actions/checkout@v4
+
+            - name: Action Ansible Galaxy Release ${{ github.ref_name }}
+              uses: ansible-actions/ansible-galaxy-action@main
               with:
-                  galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
-                  git_branch: main
+                galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}

--- a/tasks/section_2/cis_2.2.x.yml
+++ b/tasks/section_2/cis_2.2.x.yml
@@ -330,23 +330,23 @@
 
 - name: "2.2.17 | PATCH | Ensure rsync service is either not installed or masked"
   block:
-    - name: "2.2.17 | PATCH | Ensure rsync service is either not installed or masked | remove pkg"
-      ansible.builtin.package:
-          name: rsync
-          state: absent
-      when:
-          - ubtu20cis_rule_2_2_17
-          - ubtu20cis_rsync_server == 'remove'
+      - name: "2.2.17 | PATCH | Ensure rsync service is either not installed or masked | remove pkg"
+        ansible.builtin.package:
+            name: rsync
+            state: absent
+        when:
+            - ubtu20cis_rule_2_2_17
+            - ubtu20cis_rsync_server == 'remove'
 
-    - name: "2.2.17 | PATCH | Ensure rsync service is either not installed or masked | mask service"
-      ansible.builtin.service:
-          name: rsync.service
-          state: stopped
-          enabled: false
-          masked: true
-      when:
-          - ubtu20cis_rule_2_2_17
-          - ubtu20cis_rsync_server == 'mask'
+      - name: "2.2.17 | PATCH | Ensure rsync service is either not installed or masked | mask service"
+        ansible.builtin.service:
+            name: rsync.service
+            state: stopped
+            enabled: false
+            masked: true
+        when:
+            - ubtu20cis_rule_2_2_17
+            - ubtu20cis_rsync_server == 'mask'
   when:
       - "'rsync' in ansible_facts.packages"
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Update to workflows

move action/checkout to v4
use the sleep variable for sleep time during run (some OSs going slower on build)
update the update_galaxy role to use new code for galaxy-ng

lint on 2.2.17

