### PR TITLE
CIS 2.1.1.1 should not fail if systemd-timesyncd is not installed

### DIFF
--- a/tasks/section_2/cis_2.1.1.x.yml
+++ b/tasks/section_2/cis_2.1.1.x.yml
@@ -22,7 +22,9 @@
             state: stopped
             enabled: false
             masked: true
-        when: ubtu20cis_time_sync_tool != "systemd-timesyncd"
+        when:
+            - ubtu20cis_time_sync_tool != "systemd-timesyncd"
+            - "'systemd-timesyncd' in ansible_facts.packages"
   when:
       - ubtu20cis_rule_2_1_1_1
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Added a check to "when' for checking if systemd-timesyncd.service is enabled.

Currently, if the package is not installed, the task fails because the systemd check is looking for a service that does not exist. It is clear from the CIS test code that not having the package installed is a valid configuration:

> if systemctl list-units --all --type=service | grep -q 'systemd-timesyncd.service' && systemctl is-enabled systemd-timesyncd.service | grep -Eq '(enabled|disabled|masked)'; then

Note how in the CIS script, the systemctl test is only performed if the package is an available service. As a result, instead of reporting a failure, the test is skipped...which maybe is not perfect, but seems much better.
 
**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Has been run against instances without systemd-timesyncd installed. The test within the 2.1.1.1 block for the service is skipped instead of failing.
