### PR TITLE
Fix/cis 5 2 4 5 loop

### DIFF
--- a/tasks/section_5/cis_5.2.4.x.yml
+++ b/tasks/section_5/cis_5.2.4.x.yml
@@ -65,7 +65,7 @@
   ansible.builtin.file:
       path: "{{ item.path }}"
       mode: '0640'
-  loop: "{{ auditd_conf_files.files }}"
+  loop: "{{ auditd_conf_files.files|default({})}}"
   loop_control:
       label: "{{ item.path }}"
   when:

--- a/tasks/section_5/cis_5.2.4.x.yml
+++ b/tasks/section_5/cis_5.2.4.x.yml
@@ -65,7 +65,7 @@
   ansible.builtin.file:
       path: "{{ item.path }}"
       mode: '0640'
-  loop: "{{ auditd_conf_files.files|default({})}}"
+  loop: "{{ auditd_conf_files.files|default([])}}"
   loop_control:
       label: "{{ item.path }}"
   when:


### PR DESCRIPTION
**Overall Review of Changes:**
Added a default value when `ubtu20cis_rule_5_2_4_5` is skipped

**Issue Fixes:**
Since `ubtu20cis_rule_5_2_4_5` relies on a prelim register when it's skip the register doesn't populate the value of: `auditd_conf_files` which will results in the following error if `ubtu20cis_rule_5_2_4_5` is skipped. 

> dict object' has no attribute 'files'

This is a known behaviour of ansible since even if the when condition is not met the loop operation will be computed. 

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A
I run the breaking ansible pass with `ubtu20cis_rule_5_2_4_5` set to false and it did throw any error. 