### PR TITLE
Run post_remediation - quote group_names

### DIFF
--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Post Audit | Run post_remediation {{ benchmark }} audit
-  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
+  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g \"{{ group_names }}\""
   changed_when: true
   environment:
       AUDIT_BIN: "{{ audit_bin }}"

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -77,7 +77,7 @@
       mode: '0600'
 
 - name: Pre Audit | Run pre_remediation {{ benchmark }} audit
-  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
+  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g \"{{ group_names }}\""
   changed_when: true
   environment:
       AUDIT_BIN: "{{ audit_bin }}"


### PR DESCRIPTION
**Overall Review of Changes:**
Where run_audit.sh is called from ansible quote the group_name, as it can be a list containing a space.

To resolve a error

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses
N/A
Resolves issue where there is more than one group, and the -g options fails due to space in command.
`/opt/UBUNTU20-CIS-Audit/run_audit.sh  ...  -g ['all_dev', 'webservers_dev']`


**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
- fixed issue in local env that happens when a host belongs to more than one group.

