### PR TITLE
fix prelim check to check for AIDE install rule and updates rule

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -51,11 +51,11 @@
   ansible.builtin.package:
       update_cache: true
   when:
-      - ubtu20cis_rule_1_3_1 or
-        ubtu20cis_rule_1_9
+      - ubtu20cis_rule_1_2_1 or
+        ubtu20cis_rule_1_3_1
   tags:
       - rule_1.3.1
-      - rule_1.9
+      - rule_1.2.1
       - always
 
 - name: "PRELIM | Check for autofs service"


### PR DESCRIPTION
**Overall Review of Changes:**
I changed the rule numbers to what I think they were intended to be

**Issue Fixes:**
Changed the rule numbers that were copied from U22 prelim to be the U20 equivalent (1.9 doesn't exist in U20 and was erroring)

**Enhancements:**

**How has this been tested?:**
tested locally
