### PR TITLE
Fix regex to prevent swallowing closing quote in bootloader config.

### DIFF
--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -39,8 +39,8 @@
             regexp: "{{ item.regexp }}"
             replace: "{{ item.replace }}"
         with_items:
-            - { regexp: 'apparmor=\S+', replace: 'apparmor=1' }
-            - { regexp: 'security=\S+', replace: 'security=apparmor' }
+            - { regexp: 'apparmor=[^\s"]+', replace: 'apparmor=1' }
+            - { regexp: 'security=[^\s"]+', replace: 'security=apparmor' }
         when:
             - "'apparmor' in ubtu20cis_1_6_1_2_cmdline_settings.stdout"
             - "'security' in ubtu20cis_1_6_1_2_cmdline_settings.stdout"


### PR DESCRIPTION
**Overall Review of Changes:**
Fix regex to prevent swallowing closing quote in bootloader config.

**Issue Fixes:**
#132 

**Enhancements:**
Please list any enhancements/features that are not open issue tickets: None

**How has this been tested?:**
Ran against and existing system. Quote was no longer removed from output.

before:
```
$ git -C roles/UBUNTU20-CIS checkout devel
Already on 'devel'
Your branch is up to date with 'origin/devel'.
$ ansible-playbook -i inventory.yml -l ... -e ubtu20cis_section1_patch=true cis-ubuntu20.yml  -CD

PLAY [ubuntu] ************************************************************************************************************************************************

TASK [UBUNTU20-CIS : 1.6.1.2 | PATCH | Ensure AppArmor is enabled in the bootloader configuration | Set apparmor settings if none exist | Replace apparmor settings when exists] ***
--- before: /etc/default/grub
+++ after: /etc/default/grub
@@ -30,5 +30,5 @@
 
 # Uncomment to get a beep at grub start
 #GRUB_INIT_TUNE="480 440 1"
-GRUB_CMDLINE_LINUX="audit=1 audit_backlog_limit=8192 apparmor=1 security=apparmor"
+GRUB_CMDLINE_LINUX="audit=1 audit_backlog_limit=8192 apparmor=1 security=apparmor
 

changed: [...] => (item={'regexp': 'security=\\S+', 'replace': 'security=apparmor'})
```

After
```
$ git -C roles/UBUNTU20-CIS checkout AppArmor-bootloader-quoting
Switched to branch 'AppArmor-bootloader-quoting'
Your branch is up to date with 'fork/AppArmor-bootloader-quoting'.
$ ansible-playbook -i inventory.yml -l use1-dev-app0.bioraft.net -e ubtu20cis_section1_patch=true cis-ubuntu20.yml  -CD

PLAY [ubuntu] ************************************************************************************************************************************************

PLAY RECAP ***************************************************************************************************************************************************
use1-dev-app0.bioraft.net  : ok=75   changed=0    unreachable=0    failed=0    skipped=482  rescued=0    ignored=0   
```
