### PR TITLE
use ubtu20cis_auditd[admin_space_left_action]

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -727,15 +727,16 @@ ubtu20cis_remote_log_server: 192.168.2.100
 ubtu20cis_audit_back_log_limit: 8192
 
 # ubtu20cis_max_log_file_size is largest the log file will become in MB
-# This shoudl be set based on your sites policy
+# This should be set based on your sites policy
 ubtu20cis_max_log_file_size: 10
 
-#
+# ubtu20cis_auditd sets actions for admin_space_left_action and max_log_file_action
+# CIS allows admin_space_left_action of "halt" or "single"
 ubtu20cis_auditd:
     admin_space_left_action: halt
     max_log_file_action: keep_logs
 
-# ubtu20cis_logrotate is the log rotate frequencey. Options are daily, weekly, monthly, and yearly
+# ubtu20cis_logrotate is the log rotate frequency. Options are daily, weekly, monthly, and yearly
 ubtu20cis_logrotate: "daily"
 
 # Control 4.3

--- a/tasks/section_5/cis_5.2.2.x.yml
+++ b/tasks/section_5/cis_5.2.2.x.yml
@@ -41,7 +41,7 @@
   with_items:
       - { regexp: '^space_left_action', line: 'space_left_action = email' }
       - { regexp: '^action_mail_acct', line: 'action_mail_acct = root' }
-      - { regexp: '^admin_space_left_action', line: 'admin_space_left_action = halt' }
+      - { regexp: '^admin_space_left_action', line: "admin_space_left_action = {{ ubtu20cis_auditd['admin_space_left_action'] }}" }
   notify: restart auditd
   when:
       - ubtu20cis_rule_5_2_2_3


### PR DESCRIPTION
**Overall Review of Changes:**
This change enables ubtu20cis_auditd['admin_space_left_action']

**Issue Fixes:**
None

**Enhancements:**
There is a setting for ubtu20cis_auditd['admin_space_left_action'] in defaults/main.yml -- this PR uses the
variable in tasks/section_5/cis_5.2.2.x.yml 5.2.2.3 in just the same fashion that ubtu20cis_auditd['max_log_file_action']
is used for 5.2.2.2

**How has this been tested?:**
Patch applied to local branch and tested with each values of 'single' and 'halt'

