### PR TITLE
Do not make bootloader config less secure

### DIFF
--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -50,6 +50,7 @@
             mode: 0600
         when:
             - ubtu20cis_1_4_2_grub_cfg_status.stat.exists
+            - ubtu20cis_1_4_2_grub_cfg_status.stat.mode != "0400"
   when:
       - ubtu20cis_rule_1_4_2
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
As currently written, "1.4.2 | PATCH | Ensure permissions on bootloader config are configured"
will make a bootloader config with a permission of 0400 into 0600, potentially less secure. This
change insures that if the bootloader config file has a mode of 0400, it will be left as is.

**Issue Fixes:**
No linking issues

**Enhancements:**
Ensures that mode 0400 bootloader config file permissions are not more less restrictive.

**How has this been tested?:**
```
$ # UNCHANGED CODE - fixes 0444 as expected
$ ansible-playbook -i inventory.yml -l 'server.example.net' -CD cis-ubuntu.yml

PLAY [ubuntu] *********************************************************************************************************

TASK [UBUNTU20-CIS : PRELIM | Run apt update] *************************************************************************
changed: [server.example.net]

TASK [UBUNTU20-CIS : 1.4.2 | PATCH | Ensure permissions on bootloader config are configured | Set permissions] ********
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0444",
+    "mode": "0600",
     "path": "/boot/grub/grub.cfg"
 }

changed: [server.example.net]

PLAY RECAP ************************************************************************************************************
server.example.net  : ok=76   changed=2    unreachable=0    failed=0    skipped=479  rescued=0    ignored=0   

$ # CHANGED CODE - fixes 0444 as expected
$ ansible-playbook -i inventory.yml -l 'server.example.net' -CD cis-ubuntu.yml

PLAY [ubuntu] *********************************************************************************************************

TASK [UBUNTU20-CIS : PRELIM | Run apt update] *************************************************************************
changed: [server.example.net]

TASK [UBUNTU20-CIS : 1.4.2 | PATCH | Ensure permissions on bootloader config are configured | Set permissions] ********
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0444",
+    "mode": "0600",
     "path": "/boot/grub/grub.cfg"
 }

changed: [server.example.net]

PLAY RECAP ************************************************************************************************************
server.example.net  : ok=76   changed=2    unreachable=0    failed=0    skipped=479  rescued=0    ignored=0   

$ ssh -q server.example.net sudo chmod 0600 /boot/grub/grub.cfg
$ # UNCHANGED CODE - keeps 0600 as expected
$ ansible-playbook -i inventory.yml -l 'server.example.net' -CD cis-ubuntu.yml

PLAY [ubuntu] *********************************************************************************************************

TASK [UBUNTU20-CIS : PRELIM | Run apt update] *************************************************************************
changed: [server.example.net]

PLAY RECAP ************************************************************************************************************
server.example.net  : ok=76   changed=1    unreachable=0    failed=0    skipped=479  rescued=0    ignored=0   

$ # CHANGED CODE - keeps 0600 as expected
$ ansible-playbook -i inventory.yml -l 'server.example.net' -CD cis-ubuntu.yml

PLAY [ubuntu] *********************************************************************************************************

TASK [UBUNTU20-CIS : PRELIM | Run apt update] *************************************************************************
changed: [server.example.net]

PLAY RECAP ************************************************************************************************************
server.example.net  : ok=76   changed=1    unreachable=0    failed=0    skipped=479  rescued=0    ignored=0   

$ ssh -q server.example.net sudo chmod 0400 /boot/grub/grub.cfg
$ # UNCHANGED CODE - changes to less restrictive 0600, contrary to CIS benchmark
$ ansible-playbook -i inventory.yml -l 'server.example.net' -CD cis-ubuntu.yml

PLAY [ubuntu] *********************************************************************************************************

TASK [UBUNTU20-CIS : PRELIM | Run apt update] *************************************************************************
changed: [server.example.net]

TASK [UBUNTU20-CIS : 1.4.2 | PATCH | Ensure permissions on bootloader config are configured | Set permissions] ********
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0400",
+    "mode": "0600",
     "path": "/boot/grub/grub.cfg"
 }

changed: [server.example.net]

PLAY RECAP ************************************************************************************************************
server.example.net  : ok=76   changed=2    unreachable=0    failed=0    skipped=479  rescued=0    ignored=0   

$ # CHANGED CODE - keeps 0400 as provided for in CIS benchmark
$ ansible-playbook -i inventory.yml -l 'server.example.net' -CD cis-ubuntu.yml

PLAY [ubuntu] *********************************************************************************************************

TASK [UBUNTU20-CIS : PRELIM | Run apt update] *************************************************************************
changed: [server.example.net]

PLAY RECAP ************************************************************************************************************
server.example.net  : ok=75   changed=1    unreachable=0    failed=0    skipped=480  rescued=0    ignored=0   

$ 
```

