### PR TITLE
Fix incorrect tag on cis_5.1.1.1.x.yml

### DIFF
--- a/tasks/section_5/cis_5.1.1.1.x.yml
+++ b/tasks/section_5/cis_5.1.1.1.x.yml
@@ -42,7 +42,7 @@
       state: started
       enabled: true
   when:
-      - ubtu20cis_rule_5.1.1.1.3
+      - ubtu20cis_rule_5_1_1_1_3
   tags:
       - level1-server
       - level1-workstation
@@ -57,7 +57,7 @@
       state: stopped
       enabled: false
   when:
-      - ubtu20cis_rule_5.1.1.1.4
+      - ubtu20cis_rule_5_1_1_1_4
       - not journald_log_server
   tags:
       - level1-server


### PR DESCRIPTION
**Overall Review of Changes:**
The tag are not match between default variable and tasks.

**Issue Fixes:**
Ansible is able to skip tag on 5.1.1.1.3 and 5.1.1.1.4
