### PR TITLE
fix(4.5.2): skip accounts already configured with nologin/false shell

### DIFF
--- a/tasks/section_4/cis_4.5.x.yml
+++ b/tasks/section_4/cis_4.5.x.yml
@@ -4,25 +4,25 @@
   block:
       - name: "4.5.2 | PATCH | Ensure system accounts are secured | Set system accounts to nologin"
         ansible.builtin.user:
-            name: "{{ item }}"
+            name: "{{ item.id }}"
             shell: /sbin/nologin
-        with_items:
-            - "{{ ubtu20cis_passwd | selectattr('uid', '<', 1000) | map(attribute='id') | list }}"
+        loop: "{{ ubtu20cis_passwd | selectattr('uid', '<', 1000) | list }}"
+        loop_control:
+            label: "{{ item.id }}"
         when:
-            - item != "root"
-            - item != "sync"
-            - item != "shutdown"
-            - item != "halt"
-            - item != "irc"
+            - item.id not in ['root', 'sync', 'shutdown', 'halt', 'irc']
+            - item.shell not in ['/sbin/nologin', '/usr/sbin/nologin', '/bin/false']
 
       - name: "4.5.2 | PATCH | Ensure system accounts are secured | Lock non-root system accounts"
         ansible.builtin.user:
-            name: "{{ item }}"
+            name: "{{ item.id }}"
             password_lock: true
-        with_items:
-            - "{{ ubtu20cis_passwd | selectattr('uid', '<', 1000) | map(attribute='id') | list }}"
+        loop: "{{ ubtu20cis_passwd | selectattr('uid', '<', 1000) | list }}"
+        loop_control:
+            label: "{{ item.id }}"
         when:
-            - item != "root"
+            - item.id != "root"
+            - item.shell not in ['/sbin/nologin', '/usr/sbin/nologin', '/bin/false']
   when:
       - ubtu20cis_rule_4_5_2
       - ubtu20cis_disruption_high


### PR DESCRIPTION
## Problem                                                              

  The 4.5.2 task iterates **all** system accounts (UID < UID_MIN) and
  unconditionally calls `ansible.builtin.user` to set shell and lock them,
  even when those accounts are already fully compliant.

  This produces **false positives**: every
  system account already set to `/sbin/nologin` is reported as "would
  change", inflating the non-compliance count and making the remediation
  appear non-idempotent.

  A common trigger is Debian/Ubuntu service accounts whose home is
  `/nonexistent` — they ship with `/sbin/nologin` already, yet are
  constantly flagged.

  ## Root cause

  The CIS 4.5.2 benchmark definition targets only accounts that still
  have a **valid login shell**. [The reference audit script](https://www.tenable.com/audits/items/CIS_Debian_Linux_10_v2.0.0_L1_Server.audit:da60f23fda53dd76316a0498c022994e) (e.g. Tenable
  CIS_Debian_Linux_10_v2.0.0 audit id `da60f23f`) uses:

  ```bash
  l_valid_shells="^($( awk -F\/ '$NF != "nologin" {print}' /etc/shells |
  ... ))$"
  # only flags: uid < UID_MIN AND shell ~ l_valid_shells
  ``` 

  Accounts already on nologin / false are explicitly out of scope.

  ## Fix

  Add item.shell not in ['/sbin/nologin', '/usr/sbin/nologin',
  '/bin/false']
  to the when guard of both subtasks. This requires switching from
  with_items + map(attribute='id') to loop over the full object so
  that item.shell is accessible.

  ## Effect

  - No behaviour change on non-compliant systems (accounts with a valid
  login shell are still remediated).
  - Audit (--check) mode no longer reports already-compliant accounts
  as drifted.
  - Remediation becomes truly idempotent: running the playbook twice
  produces changed=0 on the second run.
